### PR TITLE
link to links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,7 +40,7 @@ ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "public/"]
     weight = 3
 
  [[menu.main]]
-    url = "/links/links.md"
+    url = "/links/links"
     name = "Links"
     weight = 4
     


### PR DESCRIPTION
Hugo/Blogdown renders all of the `.md` files into `.html` and stores the result in the `public/`. So if you ever want to see exactly where something is it's a useful trick.

Any web browser will look for `index.html` in a folder so you don't need to be explicit about the file name. Because of how the theme is built, you `links/` takes you to a list page with up to 10 items(blogs) on it, so to get all the way down you `links/links/` here.

https://github.com/nathancday/min_night/issues/9
